### PR TITLE
Fix `parseAuto()` error on empty string (and handle white space too)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ This file tracks notable changes to **nrelUtilityExt**. The format is based on
 
 - Reorganized functions into multiple package files for easier maintenance
 - Reorganized documentation to group more functions by category
+- `parseAuto()` now trims leading and trailing white space before parsing
+
+### Fixed
+
+- `parseAuto()` now returns Null on empty string instead of an error
 
 ### Removed
 

--- a/lib/parsingFuncs.trio
+++ b/lib/parsingFuncs.trio
@@ -1,6 +1,6 @@
 name:parseAuto
 doc:
-  Parse a `sys::Str` 'val', automatically guessing its data type. Supports all `docHaystack::Zinc` data types plus the following keywords:
+  Parse a [Str]`sys::Str` 'val', automatically guessing its data type. Supports all `docHaystack::Zinc` data types plus the following keywords:
   
   - True: 'true', 'True', or 'TRUE' (as Bool)
   - False: 'false', 'False', or 'FALSE' (as Bool)
@@ -12,7 +12,20 @@ doc:
   
   For everything else, this function wraps `ioReadZinc`. The resulting parsing behavior supports most basic [Axon]`docHaxall::AxonLang` data types, but ranges, triple-quoted string literals, and raw string literals are not supported.
   
-  If parsing fails and 'checked' is 'false' returns null; otherwise throws an error.
+  Implementation Notes:
+  
+  - Leading and trailing white space characters are trimmed prior to parsing
+  - Returns null if 'val' is an empty string
+  - If parsing fails and 'checked' is 'false' returns null; otherwise throws an error.
+  
+  Examples:
+  
+    parseAuto("2kW")                >> 2kW              // Number
+    parseAuto("+INF")               >> ∞                // Number
+    parseAuto("{foo bar:\"baz\"}")  >> {foo, bar:"baz"} // Dict
+    parseAuto("[1, 2, 5]")          >> [1, 2, 5]        // List
+    parseAuto("\"Three sir!\"")     >> "Three sir!"     // Str
+    parseAuto(" ")                  >> null
 func
 overridable
 src:
@@ -22,7 +35,13 @@ src:
       // Check input
       if (not val.isStr) throw "'val' must a string."
       if (val.contains("\n")) throw "'val' must not contain newline characters."
-  
+      
+      // Trim
+      val = val.trim
+    
+      // Empty string
+      if (val.isEmpty) return null
+      
       // Keywords: True, False, Null, NA, NaN, +Inf, -Inf
       if (val == "true"  or val == "True"  or val == "TRUE" ) return true
       if (val == "false" or val == "False" or val == "FALSE") return false
@@ -31,18 +50,15 @@ src:
       if (val == "nan"   or val == "NaN"   or val == "NAN"  ) return nan()
       if (val == "+inf"  or val == "+Inf"  or val == "+INF" ) return posInf()
       if (val == "-inf"  or val == "-Inf"  or val == "-INF" ) return negInf()
-  
+
       // Parse using ZINC grammar
       return ioReadZinc("ver:\"3.0\"\nval\n" + val).first["val"] 
-    
+
     // Catch block
     catch (ex) do
       if (checked) throw (ex)
       return null
     end
-    
-    // TO DO: Unit test(s)
-    // parseAuto("{a, b:0kW, c:[1, 2, 5], d:\"Three sir!\", e:{foo bar:\"baz\"}}")
   end
 ---
 name:parseCoord

--- a/test/tests.txt
+++ b/test/tests.txt
@@ -1,0 +1,9 @@
+/// Automated tests to implement in the future ///
+
+// parsing functions //
+parseAuto("2kW")                // 2kW              // Number
+parseAuto("+INF")               // ∞                // Number
+parseAuto("{foo bar:\"baz\"}")  // {foo, bar:"baz"} // Dict
+parseAuto("[1, 2, 5]")          // [1, 2, 5]        // List
+parseAuto("\"Three sir!\"")     // "Three sir!"     // Str
+parseAuto(" ")                  // null


### PR DESCRIPTION
Fixes #10